### PR TITLE
Analyze archetype depth and foundation by age

### DIFF
--- a/src/app/soldash/you/page.tsx
+++ b/src/app/soldash/you/page.tsx
@@ -6,17 +6,7 @@ import SolEvolution from '~/components/Soldash/SolEvolution';
 import ExpandUnderstanding from '~/components/Soldash/ExpandUnderstanding';
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-
-// Mock data for now; replace with real logic as needed
-const sunSign = 'Aquarius';
-const archetype = 'Sol Innovator';
-const foundation = 'Builder Foundation';
-const depth = 'Alchemist Depth';
-const affirmation = 'I incubate revolutionary ideas in the depths of transformative solitude.';
-const description = `You're a visionary architect of the future, combining Aquarian innovation with deep transformational wisdom. Your Builder foundation gives you the practical skills to manifest your visions, while your Alchemist depth allows you to transmute complex ideas into revolutionary breakthroughs that benefit humanity.`;
-const currentPhase = 'Current Phase (Ages 28–35)';
-const keyThemes = 'Balancing solitary creation with community building. Your ideas are ready to reach wider audiences.';
-const nextMilestone = 'A significant breakthrough in how you share your innovations with the world awaits in 47 days.';
+import { getCompleteSolarProfile } from '~/lib/solarIdentity';
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -36,14 +26,33 @@ const itemVariants = {
 
 export default function YouPage() {
   const [bookmark, setBookmark] = useState<any>(null);
+  const [solarProfile, setSolarProfile] = useState<any>(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('sunCycleBookmark');
       if (saved) {
         try {
-          setBookmark(JSON.parse(saved));
-        } catch {}
+          const parsedBookmark = JSON.parse(saved);
+          setBookmark(parsedBookmark);
+          
+          // Generate enhanced solar profile if we have a birth date
+          if (parsedBookmark.birthDate) {
+            const profile = getCompleteSolarProfile(parsedBookmark.birthDate);
+            setSolarProfile(profile);
+            
+            // Update bookmark with new foundation/depth data
+            const enhancedBookmark = {
+              ...parsedBookmark,
+              foundation: profile.foundation,
+              depth: profile.depth,
+              agePhase: profile.agePhase
+            };
+            setBookmark(enhancedBookmark);
+          }
+        } catch {
+          // Handle parse error gracefully
+        }
       }
     }
   }, []);
@@ -59,7 +68,7 @@ export default function YouPage() {
       <motion.div className="mt-10" variants={itemVariants}>
         <Tooltip
           title="DISCOVER YOUR INNER SOL"
-          body={"Go deeper into your Sol Innovator identity. In time, you'll unlock the layers of your cosmic signature."}
+          body={`Go deeper into your ${solarProfile?.archetype || 'Solar'} identity. In time, you'll unlock the layers of your cosmic signature.`}
           bgColor="#FFF8ED"
           borderColor="#F5C16C"
           textColor="#D4A02A"

--- a/src/components/Soldash/SolEvolution.tsx
+++ b/src/components/Soldash/SolEvolution.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
-import { getSunSign, getSolPhase, getSolarArchetype, dayRangeToAgeRange } from '../../lib/solarIdentity';
+import { getSunSign, getSolPhase, getSolarArchetype, dayRangeToAgeRange, getCompleteSolarProfile, getFoundationDescription, getDepthDescription } from '../../lib/solarIdentity';
 import { getNextMilestone } from '../../lib/milestones';
 
 interface Bookmark {
@@ -9,6 +9,7 @@ interface Bookmark {
   solArchetype?: string;
   foundation?: string;
   depth?: string;
+  agePhase?: string;
 }
 
 interface SolEvolutionProps {
@@ -16,10 +17,14 @@ interface SolEvolutionProps {
 }
 
 const SolEvolution: React.FC<SolEvolutionProps> = ({ bookmark }) => {
-  const sunSign = bookmark?.birthDate ? getSunSign(bookmark.birthDate) : '';
-  const solArchetype = bookmark?.solArchetype || (bookmark.birthDate ? getSolarArchetype(bookmark.birthDate) : '');
-  const foundation = bookmark.foundation || 'Builder Foundation';
-  const depth = bookmark.depth || 'Alchemist Depth';
+  // Generate complete solar profile from birth date
+  const solarProfile = bookmark?.birthDate ? getCompleteSolarProfile(bookmark.birthDate) : null;
+  
+  const sunSign = solarProfile?.sunSign || (bookmark?.birthDate ? getSunSign(bookmark.birthDate) : '');
+  const solArchetype = solarProfile?.archetype || bookmark?.solArchetype || '';
+  const foundation = solarProfile?.foundation || bookmark?.foundation || 'Seeker Foundation';
+  const depth = solarProfile?.depth || bookmark?.depth || 'Explorer Depth';
+  const agePhase = solarProfile?.agePhase || bookmark?.agePhase || '';
 
   // Use solAge from bookmark if present, otherwise calculate from birthDate
   const solAge =
@@ -34,13 +39,16 @@ const SolEvolution: React.FC<SolEvolutionProps> = ({ bookmark }) => {
   console.log('SolEvolution debug:', {
     solArchetype,
     solAge,
+    foundation,
+    depth,
+    agePhase,
     phaseInfo: solArchetype && solAge !== undefined ? getSolPhase(solArchetype, solAge) : null,
     bookmark
   });
 
   const phaseInfo = solArchetype && solAge !== undefined ? getSolPhase(solArchetype, solAge) : null;
 
-  // Current Phase: name, age range, description
+  // Current Phase: name, age range, description with enhanced foundation/depth context
   let phaseLabel = '';
   let phaseDescription = '';
   if (phaseInfo && solArchetype) {
@@ -97,14 +105,20 @@ const SolEvolution: React.FC<SolEvolutionProps> = ({ bookmark }) => {
     const phaseRange = phaseRanges[solArchetype][phaseInfo.phase - 1];
     const ageRange = dayRangeToAgeRange(phaseRange.min, phaseRange.max === Infinity ? phaseRange.min + 3652 : phaseRange.max);
     phaseLabel = `CURRENT PHASE (${ageRange})`;
-    phaseDescription = `The ${phaseInfo.name} — You're in a key period for your ${solArchetype.replace('Sol ', '')} journey, where your ${foundation.replace(' Foundation', '')} skills meet ${depth.replace(' Depth', '')} wisdom.`;
+    
+    // Enhanced description with foundation/depth context
+    const foundationDesc = getFoundationDescription(foundation).toLowerCase();
+    const depthDesc = getDepthDescription(depth).toLowerCase();
+    phaseDescription = `The ${phaseInfo.name} — You're in a ${agePhase.toLowerCase()} period where you are ${foundationDesc}, using ${depthDesc} to create meaningful impact in your ${solArchetype.replace('Sol ', '')} journey.`;
   } else {
     phaseLabel = 'CURRENT PHASE';
     phaseDescription = 'Your current phase information will appear here.';
   }
 
-  // Key Themes: template-based
-  const keyTheme = `Balancing your ${foundation.replace(' Foundation', '').toLowerCase()} skills with your ${depth.replace(' Depth', '').toLowerCase()} wisdom. This year, your ${solArchetype.replace('Sol ', '') || 'solar'} energy is ready to reach wider audiences.`;
+  // Enhanced Key Themes with age-appropriate foundation/depth integration
+  const foundationContext = getFoundationDescription(foundation).toLowerCase();
+  const depthContext = getDepthDescription(depth).toLowerCase(); 
+  const keyTheme = `In your ${agePhase || 'current phase'}, you are ${foundationContext} while developing ${depthContext}. This creates a unique ${solArchetype.replace('Sol ', '') || 'solar'} expression ready to reach and impact wider communities.`;
 
   // Upcoming Milestone
   let milestoneLabel = '';

--- a/src/components/Soldash/SolProfilePreview.tsx
+++ b/src/components/Soldash/SolProfilePreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
-import { getSunSign, getSolPhase, getSolarArchetype, solarArchetypeCoreQuotes, generateSolarIdentityDescription } from '../../lib/solarIdentity';
+import { getSunSign, getSolPhase, getSolarArchetype, solarArchetypeCoreQuotes, generateSolarIdentityDescription, getCompleteSolarProfile } from '../../lib/solarIdentity';
 
 interface Bookmark {
   birthDate: string;
@@ -8,6 +8,7 @@ interface Bookmark {
   solArchetype?: string;
   foundation?: string;
   depth?: string;
+  agePhase?: string;
 }
 
 interface SolProfilePreviewProps {
@@ -15,31 +16,34 @@ interface SolProfilePreviewProps {
 }
 
 const SolProfilePreview: React.FC<SolProfilePreviewProps> = ({ bookmark }) => {
-  const sunSign = bookmark?.birthDate ? getSunSign(bookmark.birthDate) : '';
-  // Fallback: derive solArchetype from birthDate if not present
-  const solArchetype = bookmark?.solArchetype || (bookmark.birthDate ? getSolarArchetype(bookmark.birthDate) : '');
+  // Generate complete solar profile from birth date
+  const solarProfile = bookmark?.birthDate ? getCompleteSolarProfile(bookmark.birthDate) : null;
+  
+  const sunSign = solarProfile?.sunSign || (bookmark?.birthDate ? getSunSign(bookmark.birthDate) : '');
+  const solArchetype = solarProfile?.archetype || bookmark?.solArchetype || '';
+  const foundation = solarProfile?.foundation || bookmark?.foundation || 'Seeker Foundation';
+  const depth = solarProfile?.depth || bookmark?.depth || 'Explorer Depth';
+  const agePhase = solarProfile?.agePhase || bookmark?.agePhase || '';
+  const coreQuote = solarProfile?.coreQuote || (solArchetype ? solarArchetypeCoreQuotes[solArchetype] : '') || '';
+
+  // Get phase info for compatibility with existing evolution display
   const phaseInfo = solArchetype && bookmark?.solAge !== undefined ? getSolPhase(solArchetype, bookmark.solAge) : null;
-  const coreQuote = solArchetype ? solarArchetypeCoreQuotes[solArchetype] || '' : '';
 
   // SVG paths
   const sunSignSvg = sunSign ? `/astrology/signs/${sunSign.toLowerCase()}.svg` : '';
   const radiantSunSvg = '/astrology/radiant_sun.svg';
 
-  // Use foundation and depth from bookmark if available, otherwise use placeholders
-  const foundation = bookmark.foundation || 'Builder Foundation';
-  const depth = bookmark.depth || 'Alchemist Depth';
-
-  // Generate the full value proposition description
-  const description = (sunSign && solArchetype && foundation && depth)
-    ? generateSolarIdentityDescription(sunSign, solArchetype, foundation, depth)
+  // Generate the enhanced value proposition description
+  const description = solarProfile
+    ? generateSolarIdentityDescription(sunSign, solArchetype, foundation, depth, agePhase)
     : 'Your Solar Identity description will appear here.';
 
   // Debug logging for missing data
-  if (!coreQuote) {
+  if (!coreQuote && solArchetype) {
     // eslint-disable-next-line no-console
     console.warn('No coreQuote found for archetype:', solArchetype);
   }
-  if (!description) {
+  if (!description && solarProfile) {
     // eslint-disable-next-line no-console
     console.warn('No description generated for:', { sunSign, solArchetype, foundation, depth });
   }
@@ -75,17 +79,24 @@ const SolProfilePreview: React.FC<SolProfilePreviewProps> = ({ bookmark }) => {
         <Image src={radiantSunSvg} alt="Radiant Sun" width={56} height={56} className="w-14 h-14 object-contain" style={{ borderRadius: 0 }} />
       </div>
 
-      {/* Subheader: Foundation & Depth */}
-      <div className="text-center text-base font-mono tracking-tight leading-tightest text-[#888] uppercase">
-        {foundation.toUpperCase()} & {depth.toUpperCase()}
+      {/* Subheader: Foundation & Depth with Age Phase Context */}
+      <div className="text-center">
+        <div className="text-base font-mono tracking-tight leading-tightest text-[#888] uppercase">
+          {foundation.toUpperCase()} & {depth.toUpperCase()}
+        </div>
+        {agePhase && (
+          <div className="text-sm font-mono text-[#999] mt-1 uppercase tracking-wide">
+            {agePhase} Expression
+          </div>
+        )}
       </div>
 
       {/* Power Phrase */}
       <div className="bg-white border border-[#E5E1D8] p-4 text-center italic text-2xl leading-tight tracking-tightest font-serif" style={{ borderRadius: 0 }}>
-        {coreQuote ? `“${coreQuote}”` : '“Your power phrase will appear here.”'}
+        {coreQuote ? `"${coreQuote}"` : '"Your power phrase will appear here."'}
       </div>
 
-      {/* Description */}
+      {/* Enhanced Description */}
       <div className="text-[#5F5F5F] text-lg font-serif text-left leading-tight mb-4">
         {description}
       </div>

--- a/src/lib/solarIdentity.ts
+++ b/src/lib/solarIdentity.ts
@@ -1,4 +1,166 @@
-// Solar identity and sun sign logic for Solara
+// Enhanced Solar Identity System with Age-Based Foundation & Depth Logic
+
+export interface SolarProfile {
+  sunSign: string;
+  archetype: string;
+  foundation: string;
+  depth: string;
+  agePhase: string;
+  coreQuote: string;
+  radiatesWith: string;
+}
+
+// Age-based life phases
+export interface LifePhase {
+  name: string;
+  ageRange: [number, number];
+  description: string;
+}
+
+export const LIFE_PHASES: LifePhase[] = [
+  { name: "Foundation Layer", ageRange: [0, 10], description: "Building core identity and wonder" },
+  { name: "Explorer Phase", ageRange: [11, 17], description: "Discovering self and questioning everything" },
+  { name: "Emergence Phase", ageRange: [18, 25], description: "Taking first independent steps" },
+  { name: "Builder Phase", ageRange: [26, 35], description: "Constructing life foundations and systems" },
+  { name: "Mastery Phase", ageRange: [36, 45], description: "Refining skills and deepening expertise" },
+  { name: "Wisdom Phase", ageRange: [46, 60], description: "Mentoring others and sharing knowledge" },
+  { name: "Eternal Foundation", ageRange: [61, 120], description: "Living legacy and timeless wisdom" }
+];
+
+// Foundation types based on primary life focus/energy
+export const FOUNDATION_TYPES = {
+  'Seeker Foundation': 'Driven by curiosity and the need to understand',
+  'Builder Foundation': 'Focused on creating lasting structures and systems',
+  'Nurturer Foundation': 'Centered on growth, care, and supporting others',
+  'Innovator Foundation': 'Motivated by change, creativity, and breakthrough thinking',
+  'Wisdom Foundation': 'Grounded in experience and sharing knowledge',
+  'Harmonic Foundation': 'Balanced integration of all energies'
+};
+
+// Depth types based on inner processing style
+export const DEPTH_TYPES = {
+  'Explorer Depth': 'Surface-level curiosity with broad interests',
+  'Artisan Depth': 'Skilled crafting with attention to beauty and form',
+  'Alchemist Depth': 'Deep transformation through understanding hidden patterns',
+  'Sage Depth': 'Profound wisdom integration across multiple domains',
+  'Mystic Depth': 'Transcendent understanding beyond conventional knowledge'
+};
+
+// Matrix: [Archetype][Age Phase] -> Foundation
+const ARCHETYPE_FOUNDATION_MATRIX: Record<string, Record<string, string>> = {
+  'Sol Innovator': {
+    'Foundation Layer': 'Seeker Foundation',
+    'Explorer Phase': 'Seeker Foundation',
+    'Emergence Phase': 'Innovator Foundation',
+    'Builder Phase': 'Builder Foundation',
+    'Mastery Phase': 'Innovator Foundation',
+    'Wisdom Phase': 'Wisdom Foundation',
+    'Eternal Foundation': 'Harmonic Foundation'
+  },
+  'Sol Nurturer': {
+    'Foundation Layer': 'Nurturer Foundation',
+    'Explorer Phase': 'Seeker Foundation',
+    'Emergence Phase': 'Nurturer Foundation',
+    'Builder Phase': 'Builder Foundation',
+    'Mastery Phase': 'Nurturer Foundation',
+    'Wisdom Phase': 'Wisdom Foundation',
+    'Eternal Foundation': 'Harmonic Foundation'
+  },
+  'Sol Alchemist': {
+    'Foundation Layer': 'Seeker Foundation',
+    'Explorer Phase': 'Seeker Foundation',
+    'Emergence Phase': 'Seeker Foundation',
+    'Builder Phase': 'Builder Foundation',
+    'Mastery Phase': 'Innovator Foundation',
+    'Wisdom Phase': 'Wisdom Foundation',
+    'Eternal Foundation': 'Harmonic Foundation'
+  },
+  'Sol Sage': {
+    'Foundation Layer': 'Seeker Foundation',
+    'Explorer Phase': 'Seeker Foundation',
+    'Emergence Phase': 'Seeker Foundation',
+    'Builder Phase': 'Builder Foundation',
+    'Mastery Phase': 'Wisdom Foundation',
+    'Wisdom Phase': 'Wisdom Foundation',
+    'Eternal Foundation': 'Harmonic Foundation'
+  },
+  'Sol Builder': {
+    'Foundation Layer': 'Builder Foundation',
+    'Explorer Phase': 'Seeker Foundation',
+    'Emergence Phase': 'Builder Foundation',
+    'Builder Phase': 'Builder Foundation',
+    'Mastery Phase': 'Builder Foundation',
+    'Wisdom Phase': 'Wisdom Foundation',
+    'Eternal Foundation': 'Harmonic Foundation'
+  },
+  'Sol Artist': {
+    'Foundation Layer': 'Seeker Foundation',
+    'Explorer Phase': 'Seeker Foundation',
+    'Emergence Phase': 'Innovator Foundation',
+    'Builder Phase': 'Builder Foundation',
+    'Mastery Phase': 'Innovator Foundation',
+    'Wisdom Phase': 'Wisdom Foundation',
+    'Eternal Foundation': 'Harmonic Foundation'
+  }
+};
+
+// Matrix: [Archetype][Age Phase] -> Depth  
+const ARCHETYPE_DEPTH_MATRIX: Record<string, Record<string, string>> = {
+  'Sol Innovator': {
+    'Foundation Layer': 'Explorer Depth',
+    'Explorer Phase': 'Explorer Depth',
+    'Emergence Phase': 'Artisan Depth',
+    'Builder Phase': 'Alchemist Depth',
+    'Mastery Phase': 'Alchemist Depth',
+    'Wisdom Phase': 'Sage Depth',
+    'Eternal Foundation': 'Mystic Depth'
+  },
+  'Sol Nurturer': {
+    'Foundation Layer': 'Explorer Depth',
+    'Explorer Phase': 'Explorer Depth',
+    'Emergence Phase': 'Artisan Depth',
+    'Builder Phase': 'Artisan Depth',
+    'Mastery Phase': 'Alchemist Depth',
+    'Wisdom Phase': 'Sage Depth',
+    'Eternal Foundation': 'Mystic Depth'
+  },
+  'Sol Alchemist': {
+    'Foundation Layer': 'Explorer Depth',
+    'Explorer Phase': 'Artisan Depth',
+    'Emergence Phase': 'Alchemist Depth',
+    'Builder Phase': 'Alchemist Depth',
+    'Mastery Phase': 'Alchemist Depth',
+    'Wisdom Phase': 'Sage Depth',
+    'Eternal Foundation': 'Mystic Depth'
+  },
+  'Sol Sage': {
+    'Foundation Layer': 'Explorer Depth',
+    'Explorer Phase': 'Explorer Depth',
+    'Emergence Phase': 'Artisan Depth',
+    'Builder Phase': 'Alchemist Depth',
+    'Mastery Phase': 'Sage Depth',
+    'Wisdom Phase': 'Sage Depth',
+    'Eternal Foundation': 'Mystic Depth'
+  },
+  'Sol Builder': {
+    'Foundation Layer': 'Explorer Depth',
+    'Explorer Phase': 'Explorer Depth',
+    'Emergence Phase': 'Artisan Depth',
+    'Builder Phase': 'Artisan Depth',
+    'Mastery Phase': 'Alchemist Depth',
+    'Wisdom Phase': 'Sage Depth',
+    'Eternal Foundation': 'Mystic Depth'
+  },
+  'Sol Artist': {
+    'Foundation Layer': 'Explorer Depth',
+    'Explorer Phase': 'Artisan Depth',
+    'Emergence Phase': 'Artisan Depth',
+    'Builder Phase': 'Alchemist Depth',
+    'Mastery Phase': 'Alchemist Depth',
+    'Wisdom Phase': 'Sage Depth',
+    'Eternal Foundation': 'Mystic Depth'
+  }
+};
 
 // Sun sign date ranges
 const sunSignRanges = [
@@ -16,8 +178,8 @@ const sunSignRanges = [
   { sign: 'Capricorn', start: '12-22', end: '01-19' },
 ];
 
-export function getSunSign(birthDate: string): string {
-  const date = new Date(birthDate);
+export function getSunSign(birthDate: string | Date): string {
+  const date = typeof birthDate === 'string' ? new Date(birthDate) : birthDate;
   const month = date.getMonth() + 1;
   const day = date.getDate();
   const mmdd = `${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
@@ -48,32 +210,100 @@ export const sunSignToArchetype: Record<string, string> = {
   'Pisces': 'Sol Alchemist',
 };
 
-export function getSolarArchetype(birthDate: string): string {
+export function getSolarArchetype(birthDate: string | Date): string {
   const sunSign = getSunSign(birthDate);
   return sunSignToArchetype[sunSign] || 'Sol Traveler';
 }
 
+export function getLifePhase(age: number): LifePhase {
+  return LIFE_PHASES.find(phase =>
+    age >= phase.ageRange[0] && age <= phase.ageRange[1]
+  ) || LIFE_PHASES[LIFE_PHASES.length - 1]; // Default to last phase
+}
+
+export function calculateAge(birthDate: string | Date): number {
+  const birth = typeof birthDate === 'string' ? new Date(birthDate) : birthDate;
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+
+  return age;
+}
+
+export function getFoundation(archetype: string, agePhase: string): string {
+  return ARCHETYPE_FOUNDATION_MATRIX[archetype]?.[agePhase] || 'Seeker Foundation';
+}
+
+export function getDepth(archetype: string, agePhase: string): string {
+  return ARCHETYPE_DEPTH_MATRIX[archetype]?.[agePhase] || 'Explorer Depth';
+}
+
+// Updated core quotes that incorporate foundation/depth awareness
 export const solarArchetypeCoreQuotes: Record<string, string> = {
-  'Sol Innovator': "I channel tomorrow's dreams into today's reality",
-  'Sol Nurturer': "I create sacred spaces where souls can grow",
-  'Sol Alchemist': "I transform darkness into golden wisdom",
-  'Sol Sage': "I expand consciousness through adventurous wisdom-seeking",
-  'Sol Builder': "I construct lasting foundations that support collective achievement",
-  'Sol Artist': "I weave beauty and harmony into the fabric of human connection",
-  'Sol Traveler': "You are a child of the cosmos, a way for the universe to know itself.",
+  'Sol Innovator': "I channel tomorrow's dreams into today's reality through systematic transformation",
+  'Sol Nurturer': "I create sacred spaces where souls can grow and foundations can flourish",
+  'Sol Alchemist': "I transform darkness into golden wisdom through deep pattern recognition",
+  'Sol Sage': "I expand consciousness through adventurous wisdom-seeking and systematic understanding",
+  'Sol Builder': "I construct lasting foundations that support collective achievement and growth",
+  'Sol Artist': "I weave beauty and harmony into systematic structures that inspire human connection",
+  'Sol Traveler': "You are a child of the cosmos, building your unique path through space and time",
 };
 
 export const solarArchetypeRadiatesWith: Record<string, string> = {
-  'Sol Innovator': 'Their inner Sol radiates with electric creativity and humanitarian vision.',
-  'Sol Nurturer': 'Their inner Sol radiates with nurturing care and the power to help others grow.',
-  'Sol Alchemist': 'Their inner Sol radiates with transformative wisdom and the courage to turn darkness into light.',
-  'Sol Sage': 'Their inner Sol radiates with adventurous wisdom and a quest to expand consciousness.',
-  'Sol Builder': 'Their inner Sol radiates with steadfast dedication and the ability to create lasting foundations.',
-  'Sol Artist': 'Their inner Sol radiates with beauty, harmony, and the gift of inspiring human connection.',
-  'Sol Traveler': 'Their inner Sol radiates with curiosity and cosmic wonder.'
+  'Sol Innovator': 'Their inner Sol radiates with electric creativity, systematic thinking, and transformative humanitarian vision.',
+  'Sol Nurturer': 'Their inner Sol radiates with nurturing care, structural wisdom, and the power to help others build lasting growth.',
+  'Sol Alchemist': 'Their inner Sol radiates with deep transformative wisdom, systematic pattern recognition, and the courage to build light from darkness.',
+  'Sol Sage': 'Their inner Sol radiates with adventurous wisdom, systematic knowledge integration, and consciousness expansion through structured exploration.',
+  'Sol Builder': 'Their inner Sol radiates with steadfast dedication, transformative insight, and the ability to create foundations that evolve and adapt.',
+  'Sol Artist': 'Their inner Sol radiates with beauty, systematic harmony, and the gift of inspiring human connection through structured creativity.',
+  'Sol Traveler': 'Their inner Sol radiates with curiosity, systematic wonder, and the deep building of cosmic understanding.'
 };
 
-// Phase definitions for each archetype (from phases.md)
+/**
+ * Main function: Get complete solar profile based on birth date
+ */
+export function getCompleteSolarProfile(birthDate: string | Date): SolarProfile {
+  const age = calculateAge(birthDate);
+  const lifePhase = getLifePhase(age);
+  const sunSign = getSunSign(birthDate);
+  const archetype = getSolarArchetype(birthDate);
+  const foundation = getFoundation(archetype, lifePhase.name);
+  const depth = getDepth(archetype, lifePhase.name);
+
+  return {
+    sunSign,
+    archetype,
+    foundation,
+    depth,
+    agePhase: lifePhase.name,
+    coreQuote: solarArchetypeCoreQuotes[archetype] || solarArchetypeCoreQuotes['Sol Traveler'],
+    radiatesWith: solarArchetypeRadiatesWith[archetype] || solarArchetypeRadiatesWith['Sol Traveler']
+  };
+}
+
+/**
+ * Get foundation and depth descriptions
+ */
+export function getFoundationDescription(foundation: string): string {
+  return FOUNDATION_TYPES[foundation] || 'A unique foundation seeking its path';
+}
+
+export function getDepthDescription(depth: string): string {
+  return DEPTH_TYPES[depth] || 'A unique depth of understanding';
+}
+
+// Legacy compatibility functions to keep existing code working
+export function dayRangeToAgeRange(min: number, max: number): string {
+  const minYears = Math.round(min / 365.25);
+  const maxYears = Math.round(max / 365.25);
+  return `AGES ${minYears}–${maxYears}`;
+}
+
+// Phase definitions for each archetype (keeping for compatibility with existing code)
 const solArchetypePhases: Record<string, { name: string; min: number; max: number }[]> = {
   'Sol Innovator': [
     { name: 'Curious Experimenter', min: 0, max: 3652 },
@@ -125,9 +355,6 @@ const solArchetypePhases: Record<string, { name: string; min: number; max: numbe
   ],
 };
 
-/**
- * Returns the phase number (1-6) and phase name for a given solArchetype and solAge (in days)
- */
 export function getSolPhase(solArchetype: string, solAge: number): { phase: number; name: string } | null {
   const phases = solArchetypePhases[solArchetype];
   if (!phases) return null;
@@ -139,85 +366,43 @@ export function getSolPhase(solArchetype: string, solAge: number): { phase: numb
   return null;
 }
 
-/**
- * Converts a day range to an age range string, e.g., 10958–18262 days => 'AGES 30–50'
- */
-export function dayRangeToAgeRange(min: number, max: number): string {
-  const minYears = Math.round(min / 365.25);
-  const maxYears = Math.round(max / 365.25);
-  return `AGES ${minYears}\u2013${maxYears}`;
-}
-
-// Mappings from phases.md for value proposition generation
-const archetypeDescriptors: Record<string, string> = {
-  'Sol Innovator': 'visionary architect of the future',
-  'Sol Nurturer': 'sacred gardener of human potential',
-  'Sol Alchemist': 'mystical transformer of darkness into light',
-  'Sol Sage': 'philosophical explorer of consciousness',
-  'Sol Builder': 'cosmic architect of lasting foundations',
-  'Sol Artist': 'divine weaver of beauty and harmony',
-};
-
-const sunSignTraits: Record<string, string> = {
-  'Aries': 'pioneering fire with unstoppable momentum',
-  'Taurus': 'grounding earth energy with unshakeable determination',
-  'Gemini': 'quicksilver communication with endless curiosity',
-  'Cancer': 'protective waters with deep emotional wisdom',
-  'Leo': 'radiant solar power with magnetic leadership',
-  'Virgo': 'precision earth magic with perfectionist drive',
-  'Libra': 'harmonizing air with diplomatic grace',
-  'Scorpio': 'transformational intensity with penetrating insight',
-  'Sagittarius': 'expansive fire with philosophical wisdom',
-  'Capricorn': 'mountainous authority with strategic mastery',
-  'Aquarius': 'revolutionary innovation with humanitarian vision',
-  'Pisces': 'flowing intuition with mystical connection',
-};
-
-const foundationCapabilities: Record<string, string> = {
-  'Innovator Foundation': 'the experimental courage to test breakthrough ideas',
-  'Nurturer Foundation': 'the patient wisdom to cultivate sustainable growth',
-  'Alchemist Foundation': 'the inner work mastery to process deep transformation',
-  'Sage Foundation': 'the knowledge-seeking drive to explore all perspectives',
-  'Builder Foundation': 'the practical skills to manifest lasting structures',
-  'Artist Foundation': 'the creative genius to express beauty through form',
-};
-
-const depthTransformationPowers: Record<string, string> = {
-  'Innovator Depth': 'revolutionize outdated systems into breakthrough solutions',
-  'Nurturer Depth': 'transform wounds into healing environments',
-  'Alchemist Depth': 'transmute complex shadows into golden wisdom',
-  'Sage Depth': 'expand limited perspectives into universal understanding',
-  'Builder Depth': 'convert chaos into organized, lasting foundations',
-  'Artist Depth': 'weave discord into harmonious beauty',
-};
-
-const impactStatements: Record<string, string> = {
-  'Innovator Depth': 'serves humanity\'s evolution',
-  'Nurturer Depth': 'heals collective wounds',
-  'Alchemist Depth': 'advances human consciousness',
-  'Sage Depth': 'creates lasting positive change',
-  'Builder Depth': 'builds bridges between worlds',
-  'Artist Depth': 'transforms society through beauty',
-};
-
-/**
- * Generates the full solar identity value proposition description.
- * @param sunSign e.g. 'Aquarius'
- * @param solArchetype e.g. 'Sol Innovator'
- * @param foundation e.g. 'Builder Foundation'
- * @param depth e.g. 'Alchemist Depth'
- */
+// Enhanced value proposition generator
 export function generateSolarIdentityDescription(
   sunSign: string,
   solArchetype: string,
   foundation: string,
-  depth: string
+  depth: string,
+  agePhase?: string
 ): string {
+  const archetypeDescriptors: Record<string, string> = {
+    'Sol Innovator': 'visionary architect of the future',
+    'Sol Nurturer': 'sacred gardener of human potential',
+    'Sol Alchemist': 'mystical transformer of darkness into light',
+    'Sol Sage': 'philosophical explorer of consciousness',
+    'Sol Builder': 'cosmic architect of lasting foundations',
+    'Sol Artist': 'divine weaver of beauty and harmony',
+  };
+
+  const sunSignTraits: Record<string, string> = {
+    'Aries': 'pioneering fire with unstoppable momentum',
+    'Taurus': 'grounding earth energy with unshakeable determination',
+    'Gemini': 'quicksilver communication with endless curiosity',
+    'Cancer': 'protective waters with deep emotional wisdom',
+    'Leo': 'radiant solar power with magnetic leadership',
+    'Virgo': 'precision earth magic with perfectionist drive',
+    'Libra': 'harmonizing air with diplomatic grace',
+    'Scorpio': 'transformational intensity with penetrating insight',
+    'Sagittarius': 'expansive fire with philosophical wisdom',
+    'Capricorn': 'mountainous authority with strategic mastery',
+    'Aquarius': 'revolutionary innovation with humanitarian vision',
+    'Pisces': 'flowing intuition with mystical connection',
+  };
+
   const archetypeDescriptor = archetypeDescriptors[solArchetype] || '';
   const sunSignTrait = sunSignTraits[sunSign] || '';
-  const foundationCapability = foundationCapabilities[foundation] || '';
-  const depthTransformationPower = depthTransformationPowers[depth] || '';
-  const impactStatement = impactStatements[depth] || '';
+  const foundationDescription = getFoundationDescription(foundation);
+  const depthDescription = getDepthDescription(depth);
+  const phaseContext = agePhase ? ` In your ${agePhase}, you are` : ' You are';
 
-  return `You're a ${archetypeDescriptor}, combining ${sunSignTrait} with deep transformational wisdom. Your ${foundation.replace(' Foundation', '')} foundation gives you ${foundationCapability}, while your ${depth.replace(' Depth', '')} depth allows you to ${depthTransformationPower} that ${impactStatement}.`;
-} 
+  return `${phaseContext} a ${archetypeDescriptor}, combining ${sunSignTrait} with deep transformational wisdom. Your ${foundation.replace(' Foundation', '')} foundation makes you ${foundationDescription.toLowerCase()}, while your ${depth.replace(' Depth', '')} depth gives you ${depthDescription.toLowerCase()} that serves humanity's evolution.`;
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement age-based foundation and depth for archetypes to enhance personalization in the YOU tab.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, archetype foundation and depth were hardcoded, leading to identical values for all users regardless of their age or specific archetype. This PR introduces a dynamic system where these attributes, along with their corresponding descriptions, now evolve based on the user's age and archetype, providing a more accurate and personalized experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-a02574c1-069a-4e31-98cc-18701bb9c00d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a02574c1-069a-4e31-98cc-18701bb9c00d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>