### PR TITLE
Update reflection link to journal

### DIFF
--- a/src/components/Journal/EntryPreviewModal.tsx
+++ b/src/components/Journal/EntryPreviewModal.tsx
@@ -77,11 +77,10 @@ export const EntryPreviewModal: React.FC<EntryPreviewModalProps> = ({
     } else {
       // Default behavior - navigate to journal with parent info in URL
       const params = new URLSearchParams({
-        tab: 'journal',
         inspired_by: entry.id,
         ...(shareId && { share_id: shareId }),
       });
-      window.location.href = `/soldash?${params.toString()}`;
+      window.location.href = `/soldash/journal?${params.toString()}`;
     }
   };
   const handleViewJourney = () => {


### PR DESCRIPTION
Fix broken link when adding a reflection from a shared journal entry by updating the redirect URL to the correct Journal page route.

---
<a href="https://cursor.com/background-agent?bcId=bc-16d1da28-2296-4d40-a6a6-04b91c30dff3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16d1da28-2296-4d40-a6a6-04b91c30dff3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>